### PR TITLE
Using Cellbase for retrieving reference bases

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -1,0 +1,14 @@
+<settings>
+    <profiles>
+        <profile>
+            <id>test</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <CELLBASE.REST.URL>http://www.ebi.ac.uk/cellbase/webservices/rest/</CELLBASE.REST.URL>
+                <CELLBASE.VERSION>v3</CELLBASE.VERSION>
+            </properties>
+        </profile>
+    </profiles>
+</settings>

--- a/eva-tools/pom.xml
+++ b/eva-tools/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>eva-tools</artifactId>
-    
+
     <!--Import dependency management from Spring Boot-->
     <dependencyManagement>
         <dependencies>
@@ -67,6 +67,21 @@
             <groupId>org.opencb.opencga</groupId>
             <artifactId>opencga-storage-core</artifactId>
             <version>${opencga.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.opencb.cellbase</groupId>
+                    <artifactId>cellbase.core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.opencb.cellbase</groupId>
+            <artifactId>cellbase-core</artifactId>
+            <version>${cellbase.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/eva-tools/src/main/java/embl/ebi/variation/eva/vcfDump/DumpMain.java
+++ b/eva-tools/src/main/java/embl/ebi/variation/eva/vcfDump/DumpMain.java
@@ -51,11 +51,21 @@ public class DumpMain {
         Config.setOpenCGAHome(System.getenv("OPENCGA_HOME") != null ? System.getenv("OPENCGA_HOME") : "/opt/opencga");
 
         QueryOptions query = new QueryOptions();
-        List<String> files = Arrays.asList("5");
-        List<String> studies = Arrays.asList("7");
-        String dbName = "batch";
-        String outputDir = "./";
+        List<String> files;         // = Arrays.asList("5");
+        List<String> studies;       // = Arrays.asList("7");
+        String dbName;              // = "batch";
+        String outputDir;           // = "./";
 
+        if (args.length == 4) {
+            dbName = args[0];
+            studies = Arrays.asList(args[1].split(","));
+            files = Arrays.asList(args[2].split(","));
+            outputDir = args[3];
+        } else {
+            System.out.println("usage: java -jar <jar> <dbName> <studies CommaSeparatedValues> <files CSV> <output directory>");
+            System.out.println("example: java -jar eva-tools-0.1.jar batch 7 5,6 ./");
+            return;
+        }
         query.put(VariantDBAdaptor.FILES, files);
         query.put(VariantDBAdaptor.STUDIES, studies);
 

--- a/eva-tools/src/main/java/embl/ebi/variation/eva/vcfDump/VariantExporter.java
+++ b/eva-tools/src/main/java/embl/ebi/variation/eva/vcfDump/VariantExporter.java
@@ -148,7 +148,9 @@ public class VariantExporter {
                     }
                 }
             } catch (Exception e) {
-                logger.info("Variant dump failed", e);
+                logger.info(String.format("Variant dump failed: \"%s:%d:%s>%s\"", variant.getChromosome(),
+                                variant.getStart(), variant.getReference(), variant.getAlternate()),
+                        e);
                 failedVariants++;
             }
         }
@@ -297,26 +299,8 @@ public class VariantExporter {
                             allelesArray = new ArrayList<>();
                             allelesArray.add(response.get(0).getSequence() + reference);
                             allelesArray.add(response.get(0).getSequence() + alternate);
+                            end = start + allelesArray.get(0).length()-1;   // -1 because end is inclusive. [start, end] instead of [start, end)
                         }
-                         /*
-                        String src = source.getAttribute("src");
-                        if (src != null) {
-                            VariantSource variantSource = sources.get(studyId);
-                            if (variantSource == null) {
-                                throw new IllegalArgumentException(String.format(
-                                        "VariantSource not available for study %s, needed in variant %s:%d:%s>%s", studyId,
-                                        variant.getChromosome(), variant.getStart(), variant.getReference(), variant.getAlternate()));
-                            }
-                            VariantFields variantFields = getVariantFields(variant, variantSource, src);
-
-                            // overwrite the initial-guess position and alleles
-                            allelesArray = new ArrayList<>();
-                            allelesArray.add(variantFields.reference);
-                            allelesArray.add(variantFields.alternate);
-                            start = variantFields.start;
-                            end = variantFields.end;
-                        }
-    //                        */
                     } else {
                         throw new IllegalArgumentException(String.format(
                                         "CellBase was not provided, needed to fill empty alleles at study %s, in variant %s:%d:%s>%s", studyId,

--- a/eva-tools/src/main/java/embl/ebi/variation/eva/vcfDump/VariantExporter.java
+++ b/eva-tools/src/main/java/embl/ebi/variation/eva/vcfDump/VariantExporter.java
@@ -238,12 +238,12 @@ public class VariantExporter {
      * behaviour:
      * * one VariantContext per study
      * * split multiallelic variant will remain split.
-     * * in case a normalized INDEL has empty alleles, the original alleles in the vcf line will be used.
+     * * in case a normalized INDEL has empty alleles, a query to cellbase will be done, to have the previous base as context
      *
      * steps:
      * * foreach variantSourceEntry, collect genotypes in its study, only if the study was requested
      * * get main variant data: position, alleles, filter...
-     * * if there are empty alleles, get them from the vcf line
+     * * if there are empty alleles, get them from cellbase
      * * get the genotypes
      * * add all (position, alleles, genotypes...) to a VariantContext for each study.
      *
@@ -277,7 +277,7 @@ public class VariantExporter {
                     genotypesPerStudy.put(studyId, new ArrayList<Genotype>());
                 }
 
-                // if there are indels, we cannot use the normalized alleles, (hts forbids empty alleles) so we have to take them from the original vcf line
+                // if there are indels, we cannot use the normalized alleles, (hts forbids empty alleles) so we have to take them from cellbase
                 boolean emptyAlleles = false;
                 for (String a : allelesArray) {
                     if (a.isEmpty()) {

--- a/eva-tools/src/test/java/embl/ebi/variation/eva/vcfDump/VariantExporterTest.java
+++ b/eva-tools/src/test/java/embl/ebi/variation/eva/vcfDump/VariantExporterTest.java
@@ -26,6 +26,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.opencb.biodata.models.variant.*;
+import org.opencb.cellbase.core.client.CellBaseClient;
 import org.opencb.datastore.core.QueryOptions;
 import org.opencb.opencga.lib.common.Config;
 import org.opencb.opencga.storage.core.StorageManagerFactory;
@@ -37,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.*;
 import java.util.zip.GZIPInputStream;
@@ -73,8 +75,13 @@ public class VariantExporterTest {
         VariantDBAdaptor variantDBAdaptor = variantStorageManager.getDBAdaptor(DB_NAME, null);
         VariantDBIterator iterator = variantDBAdaptor.iterator(query);
         VariantSourceDBAdaptor variantSourceDBAdaptor = variantDBAdaptor.getVariantSourceDBAdaptor();
+        String url = (String) Config.getStorageProperties().get("CELLBASE.REST.URL");
+        String version = (String) Config.getStorageProperties().get("CELLBASE.VERSION");
 
-        VariantExporter variantExporter = new VariantExporter();
+
+        CellBaseClient cellBaseClient = new CellBaseClient(new URI(url), version, "hsapiens");
+
+        VariantExporter variantExporter = new VariantExporter(cellBaseClient);
         List<String> outputFiles = variantExporter.VcfHtsExport(iterator, outputDir, variantSourceDBAdaptor, query);
 
         ////// checks 
@@ -107,8 +114,14 @@ public class VariantExporterTest {
         VariantDBAdaptor variantDBAdaptor = variantStorageManager.getDBAdaptor(DB_NAME, null);
         VariantDBIterator iterator = variantDBAdaptor.iterator(query);
         VariantSourceDBAdaptor variantSourceDBAdaptor = variantDBAdaptor.getVariantSourceDBAdaptor();
+        String url = (String) Config.getStorageProperties().get("CELLBASE.REST.URL");
+        String version = (String) Config.getStorageProperties().get("CELLBASE.VERSION");
 
-        VariantExporter variantExporter = new VariantExporter();
+
+        CellBaseClient cellBaseClient = new CellBaseClient(new URI(url), version, "hsapiens");
+
+
+        VariantExporter variantExporter = new VariantExporter(cellBaseClient);
         List<String> outputFiles = variantExporter.VcfHtsExport(iterator, outputDir, variantSourceDBAdaptor, query);
 
         ////////// checks
@@ -154,8 +167,14 @@ public class VariantExporterTest {
         VariantDBAdaptor variantDBAdaptor = variantStorageManager.getDBAdaptor(DB_NAME, null);
         VariantDBIterator iterator = variantDBAdaptor.iterator(query);
         VariantSourceDBAdaptor variantSourceDBAdaptor = variantDBAdaptor.getVariantSourceDBAdaptor();
+        String url = (String) Config.getStorageProperties().get("CELLBASE.REST.URL");
+        String version = (String) Config.getStorageProperties().get("CELLBASE.VERSION");
 
-        VariantExporter variantExporter = new VariantExporter();
+
+        CellBaseClient cellBaseClient = new CellBaseClient(new URI(url), version, "hsapiens");
+
+
+        VariantExporter variantExporter = new VariantExporter(cellBaseClient);
         List<String> outputFiles = variantExporter.VcfHtsExport(iterator, outputDir, variantSourceDBAdaptor, query);
         
         ////////// checks
@@ -187,15 +206,21 @@ public class VariantExporterTest {
         VariantDBAdaptor variantDBAdaptor = variantStorageManager.getDBAdaptor(DB_NAME, null);
         VariantDBIterator iterator = variantDBAdaptor.iterator(query);
         VariantSourceDBAdaptor variantSourceDBAdaptor = variantDBAdaptor.getVariantSourceDBAdaptor();
+        String url = (String) Config.getStorageProperties().get("CELLBASE.REST.URL");
+        String version = (String) Config.getStorageProperties().get("CELLBASE.VERSION");
 
-        VariantExporter variantExporter = new VariantExporter();
+
+        CellBaseClient cellBaseClient = new CellBaseClient(new URI(url), version, "hsapiens");
+
+
+        VariantExporter variantExporter = new VariantExporter(cellBaseClient);
 
         thrown.expect(IllegalArgumentException.class);  // comment this line to see the actual exception, making the test fail
         variantExporter.VcfHtsExport(iterator, outputDir, variantSourceDBAdaptor, query);
     }
 
     @Test
-    public void testMissingSrc() throws Exception {
+    public void testMissingCellbase() throws Exception {
         final VariantSource variantSource = new VariantSource("name", "fileId", "studyId", "studyName");
         List<String> samples = new ArrayList<>();
         for (int i = 0; i < 6; i++) {
@@ -217,7 +242,7 @@ public class VariantExporterTest {
         assertEquals(2, variants.size());
         removeSrc(variants);    // <---- this is the key point of the test
 
-        VariantExporter variantExporter = new VariantExporter();
+        VariantExporter variantExporter = new VariantExporter(null);
         variantContext = variantExporter.convertBiodataVariantToVariantContext(variants.get(0), sources);
 
         alleles = Arrays.asList("C", "A", ".");
@@ -248,7 +273,7 @@ public class VariantExporterTest {
         final VariantSource variantSource = new VariantSource("name", "fileId", "studyId", "studyName");
         List<String> samples = new ArrayList<>();
         for (int i = 0; i < 6; i++) {
-            samples.add("s"+i);
+            samples.add("s" + i);
         }
         variantSource.setSamples(samples);
         VariantFactory factory = new VariantVcfFactory();
@@ -259,13 +284,19 @@ public class VariantExporterTest {
         List<Variant> variants;
         Map<String, VariantContext> variantContext;
         List<String> alleles;
+        String url = (String) Config.getStorageProperties().get("CELLBASE.REST.URL");
+        String version = (String) Config.getStorageProperties().get("CELLBASE.VERSION");
+
+
+        CellBaseClient cellBaseClient = new CellBaseClient(new URI(url), version, "hsapiens");
+
 
         // test multiallelic
         String multiallelicLine = "1\t1000\tid\tC\tA,T\t100\tPASS\t.\tGT\t0|0\t0|0\t0|1\t1|1\t1|2\t0|1";
         variants = factory.create(variantSource, multiallelicLine);
         assertEquals(2, variants.size());
 
-        VariantExporter variantExporter = new VariantExporter();
+        VariantExporter variantExporter = new VariantExporter(cellBaseClient);
         variantContext = variantExporter.convertBiodataVariantToVariantContext(variants.get(0), sources);
         
         alleles = Arrays.asList("C", "A", ".");

--- a/eva-tools/src/test/java/embl/ebi/variation/eva/vcfDump/VariantExporterTest.java
+++ b/eva-tools/src/test/java/embl/ebi/variation/eva/vcfDump/VariantExporterTest.java
@@ -78,6 +78,7 @@ public class VariantExporterTest {
         String url = (String) Config.getStorageProperties().get("CELLBASE.REST.URL");
         String version = (String) Config.getStorageProperties().get("CELLBASE.VERSION");
 
+        logger.info("using cellbase: " + url + " version " + version);
 
         CellBaseClient cellBaseClient = new CellBaseClient(new URI(url), version, "hsapiens");
 

--- a/eva-tools/src/test/java/embl/ebi/variation/eva/vcfDump/VariantExporterTest.java
+++ b/eva-tools/src/test/java/embl/ebi/variation/eva/vcfDump/VariantExporterTest.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.*;
 import java.util.zip.GZIPInputStream;
@@ -48,7 +49,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Created by jmmut on 2015-10-29.
- * 
+ *
  * @author Jose Miguel Mut Lopez &lt;jmmut@ebi.ac.uk&gt;
  */
 public class VariantExporterTest {
@@ -58,10 +59,10 @@ public class VariantExporterTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
+    private static CellBaseClient cellBaseClient;
 
     @Test
     public void testVcfHtsExport() throws Exception {
-        Config.setOpenCGAHome(System.getenv("OPENCGA_HOME") != null ? System.getenv("OPENCGA_HOME") : "/opt/opencga");
 
         QueryOptions query = new QueryOptions();
 //        List<String> files = Arrays.asList("5");
@@ -75,12 +76,6 @@ public class VariantExporterTest {
         VariantDBAdaptor variantDBAdaptor = variantStorageManager.getDBAdaptor(DB_NAME, null);
         VariantDBIterator iterator = variantDBAdaptor.iterator(query);
         VariantSourceDBAdaptor variantSourceDBAdaptor = variantDBAdaptor.getVariantSourceDBAdaptor();
-        String url = (String) Config.getStorageProperties().get("CELLBASE.REST.URL");
-        String version = (String) Config.getStorageProperties().get("CELLBASE.VERSION");
-
-        logger.info("using cellbase: " + url + " version " + version);
-
-        CellBaseClient cellBaseClient = new CellBaseClient(new URI(url), version, "hsapiens");
 
         VariantExporter variantExporter = new VariantExporter(cellBaseClient);
         List<String> outputFiles = variantExporter.VcfHtsExport(iterator, outputDir, variantSourceDBAdaptor, query);
@@ -97,10 +92,9 @@ public class VariantExporterTest {
             assertTrue(delete);
         }
     }
-    
+
     @Test
     public void testVcfHtsExportSeveralStudies() throws Exception {
-        Config.setOpenCGAHome(System.getenv("OPENCGA_HOME") != null ? System.getenv("OPENCGA_HOME") : "/opt/opencga");
 
         QueryOptions query = new QueryOptions();
 //        List<String> files = Arrays.asList("5");
@@ -115,12 +109,6 @@ public class VariantExporterTest {
         VariantDBAdaptor variantDBAdaptor = variantStorageManager.getDBAdaptor(DB_NAME, null);
         VariantDBIterator iterator = variantDBAdaptor.iterator(query);
         VariantSourceDBAdaptor variantSourceDBAdaptor = variantDBAdaptor.getVariantSourceDBAdaptor();
-        String url = (String) Config.getStorageProperties().get("CELLBASE.REST.URL");
-        String version = (String) Config.getStorageProperties().get("CELLBASE.VERSION");
-
-
-        CellBaseClient cellBaseClient = new CellBaseClient(new URI(url), version, "hsapiens");
-
 
         VariantExporter variantExporter = new VariantExporter(cellBaseClient);
         List<String> outputFiles = variantExporter.VcfHtsExport(iterator, outputDir, variantSourceDBAdaptor, query);
@@ -129,27 +117,26 @@ public class VariantExporterTest {
 
         assertEquals(studies.size(), outputFiles.size());
         assertEquals(0, variantExporter.getFailedVariants());
-        
+
         // for study 7
         query.put(VariantDBAdaptor.STUDIES, Collections.singletonList("7"));
         iterator = variantDBAdaptor.iterator(query);
         assertEquals(countRows(iterator), countLines(outputFiles.get(0)));
-        
+
         // for study 8
         query.put(VariantDBAdaptor.STUDIES, Collections.singletonList("8"));
         iterator = variantDBAdaptor.iterator(query);
         assertEquals(countRows(iterator), countLines(outputFiles.get(1)));
-        
+
 
         for (String outputFile : outputFiles) {
             boolean delete = new File(outputFile).delete();
             assertTrue(delete);
         }
     }
-    
+
     @Test
     public void testFilter() throws Exception {
-        Config.setOpenCGAHome(System.getenv("OPENCGA_HOME") != null ? System.getenv("OPENCGA_HOME") : "/opt/opencga");
 
         QueryOptions query = new QueryOptions();
 //        List<String> files = Arrays.asList("5");
@@ -168,16 +155,10 @@ public class VariantExporterTest {
         VariantDBAdaptor variantDBAdaptor = variantStorageManager.getDBAdaptor(DB_NAME, null);
         VariantDBIterator iterator = variantDBAdaptor.iterator(query);
         VariantSourceDBAdaptor variantSourceDBAdaptor = variantDBAdaptor.getVariantSourceDBAdaptor();
-        String url = (String) Config.getStorageProperties().get("CELLBASE.REST.URL");
-        String version = (String) Config.getStorageProperties().get("CELLBASE.VERSION");
-
-
-        CellBaseClient cellBaseClient = new CellBaseClient(new URI(url), version, "hsapiens");
-
 
         VariantExporter variantExporter = new VariantExporter(cellBaseClient);
         List<String> outputFiles = variantExporter.VcfHtsExport(iterator, outputDir, variantSourceDBAdaptor, query);
-        
+
         ////////// checks
 
         assertEquals(studies.size(), outputFiles.size());
@@ -194,7 +175,6 @@ public class VariantExporterTest {
 
     @Test
     public void testMissingStudy() throws Exception {
-        Config.setOpenCGAHome(System.getenv("OPENCGA_HOME") != null ? System.getenv("OPENCGA_HOME") : "/opt/opencga");
 
         QueryOptions query = new QueryOptions();
         List<String> files = Arrays.asList("5");
@@ -207,12 +187,6 @@ public class VariantExporterTest {
         VariantDBAdaptor variantDBAdaptor = variantStorageManager.getDBAdaptor(DB_NAME, null);
         VariantDBIterator iterator = variantDBAdaptor.iterator(query);
         VariantSourceDBAdaptor variantSourceDBAdaptor = variantDBAdaptor.getVariantSourceDBAdaptor();
-        String url = (String) Config.getStorageProperties().get("CELLBASE.REST.URL");
-        String version = (String) Config.getStorageProperties().get("CELLBASE.VERSION");
-
-
-        CellBaseClient cellBaseClient = new CellBaseClient(new URI(url), version, "hsapiens");
-
 
         VariantExporter variantExporter = new VariantExporter(cellBaseClient);
 
@@ -285,12 +259,6 @@ public class VariantExporterTest {
         List<Variant> variants;
         Map<String, VariantContext> variantContext;
         List<String> alleles;
-        String url = (String) Config.getStorageProperties().get("CELLBASE.REST.URL");
-        String version = (String) Config.getStorageProperties().get("CELLBASE.VERSION");
-
-
-        CellBaseClient cellBaseClient = new CellBaseClient(new URI(url), version, "hsapiens");
-
 
         // test multiallelic
         String multiallelicLine = "1\t1000\tid\tC\tA,T\t100\tPASS\t.\tGT\t0|0\t0|0\t0|1\t1|1\t1|2\t0|1";
@@ -299,7 +267,7 @@ public class VariantExporterTest {
 
         VariantExporter variantExporter = new VariantExporter(cellBaseClient);
         variantContext = variantExporter.convertBiodataVariantToVariantContext(variants.get(0), sources);
-        
+
         alleles = Arrays.asList("C", "A", ".");
         assertEqualGenotypes(variants.get(0), variantContext.get(studyId), alleles);
 
@@ -338,15 +306,21 @@ public class VariantExporterTest {
      * @throws java.lang.InterruptedException
      */
     @BeforeClass
-    public static void setUpClass() throws IOException, InterruptedException {
+    public static void setUpClass() throws IOException, InterruptedException, URISyntaxException {
         cleanDBs();
         fillDB();
+
+        Config.setOpenCGAHome(System.getenv("OPENCGA_HOME") != null ? System.getenv("OPENCGA_HOME") : "/opt/opencga");
+        String url = (String) Config.getStorageProperties().get("CELLBASE.REST.URL");
+        String version = (String) Config.getStorageProperties().get("CELLBASE.VERSION");
+        logger.info("using cellbase: " + url + " version " + version);
+        cellBaseClient = new CellBaseClient(new URI(url), version, "hsapiens");
     }
 
     /**
      * Clears and populates the Mongo collection used during the tests.
-     * 
-     * @throws UnknownHostException 
+     *
+     * @throws UnknownHostException
      */
     @AfterClass
     public static void tearDownClass() throws UnknownHostException {
@@ -382,7 +356,7 @@ public class VariantExporterTest {
 
         logger.info("mongorestore exit value: " + exec.exitValue());
     }
-    
+
     private void removeSrc(List<Variant> variants) {
         for (Variant variant : variants) {
             for (VariantSourceEntry variantSourceEntry : variant.getSourceEntries().values()) {

--- a/eva-tools/src/test/java/embl/ebi/variation/eva/vcfDump/VariantExporterTest.java
+++ b/eva-tools/src/test/java/embl/ebi/variation/eva/vcfDump/VariantExporterTest.java
@@ -308,25 +308,25 @@ public class VariantExporterTest {
 
 
         // test indel
-        String indelLine = "1\t1000\tid\tC\tCA\t100\tPASS\t.\tGT\t0|0\t0|0\t0|1\t1|1\t1|0\t0|1";
+        String indelLine = "1\t1000\tid\tN\tNA\t100\tPASS\t.\tGT\t0|0\t0|0\t0|1\t1|1\t1|0\t0|1";
         variants = factory.create(variantSource, indelLine);
 
         variantContext = variantExporter.convertBiodataVariantToVariantContext(variants.get(0), sources);
-        alleles = Arrays.asList("C", "CA");
+        alleles = Arrays.asList("N", "NA");
         assertEqualGenotypes(variants.get(0), variantContext.get(studyId), alleles);
 
 
         // test multiallelic + indel
-        String multiallelicIndelLine = "1\t1000\tid\tC\tCA,T\t100\tPASS\t.\tGT\t0|0\t0|0\t0|1\t1|1\t1|2\t0|1";
+        String multiallelicIndelLine = "1\t1000\tid\tN\tNA,T\t100\tPASS\t.\tGT\t0|0\t0|0\t0|1\t1|1\t1|2\t0|1";
         variants = factory.create(variantSource, multiallelicIndelLine);
         assertEquals(2, variants.size());
 
         variantContext = variantExporter.convertBiodataVariantToVariantContext(variants.get(0), sources);
-        alleles = Arrays.asList("C", "CA", ".");
+        alleles = Arrays.asList("N", "NA", ".");
         assertEqualGenotypes(variants.get(0), variantContext.get(studyId), alleles);
 
         variantContext = variantExporter.convertBiodataVariantToVariantContext(variants.get(1), sources);
-        alleles = Arrays.asList("C", "T", ".");
+        alleles = Arrays.asList("N", "T", ".");
         assertEqualGenotypes(variants.get(1), variantContext.get(studyId), alleles);
 
     }

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -2,5 +2,5 @@
 
 git clone -b hotfix/0.5 https://github.com/opencb/opencga.git
 cd opencga
-mvn install -DskipTests
+mvn install -DskipTests --settings ../.travis.settings.xml
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <properties>
         <java.version>1.7</java.version>
         <opencga.version>0.5.2</opencga.version>
+        <cellbase.version>3.1.3</cellbase.version>
         <boot.version>1.2.6.RELEASE</boot.version>
     </properties>
 


### PR DESCRIPTION
Before we were using the field `src` to use the original alleles in case the normalization left empty alleles.

Now we use a simple implementation of querying the nuclotide before the variant, thus moving the start position one base before.

There is room for optimizing, such as grouping several queries at once to reduce delay overhead. However this is non trivial, as it is needed to handle a list of "pending variants", making the final VCF more unsorted, and making code much more complex.

Also, updated CLI to ask for species, needed for cellbase.
