### PR TITLE
fix bug: delete all databases in tests

### DIFF
--- a/eva-pipeline/src/test/java/embl/ebi/variation/eva/pipeline/jobs/VariantConfigurationTest.java
+++ b/eva-pipeline/src/test/java/embl/ebi/variation/eva/pipeline/jobs/VariantConfigurationTest.java
@@ -62,7 +62,7 @@ public class VariantConfigurationTest {
 
     private static final Logger logger = LoggerFactory.getLogger(VariantConfigurationTest.class);
 
-    // iterable doing an enum. Does it worth it?
+    // iterable doing an enum. Does it worth it? yes
     private static final String VALID_TRANSFORM = "VariantConfigurationTest_vt";
     private static final String INVALID_TRANSFORM = "VariantConfigurationTest_it";
     private static final String VALID_LOAD = "VariantConfigurationTest_vl";
@@ -496,6 +496,7 @@ public class VariantConfigurationTest {
                 VALID_CREATE_STATS,
                 VALID_LOAD_STATS,
                 VALID_PRE_ANNOT,
+                VALID_ANNOT,
                 VALID_ANNOT_LOAD
         );
     }


### PR DESCRIPTION
I think it would already worth it to do enums in the tests, instead of constant strings, for the names of the DBs

That way we would be able to iterate through all DBs to clean them, and we won't need to remember to add them to the list of DBs to remove.

I am mad at my past self.
