### PR TITLE
EVA-402: fix bug: not full path in files collection, only filename

### DIFF
--- a/eva-pipeline/src/main/java/embl/ebi/variation/eva/VariantJobsArgs.java
+++ b/eva-pipeline/src/main/java/embl/ebi/variation/eva/VariantJobsArgs.java
@@ -26,6 +26,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.nio.file.Paths;
+
 /**
  *
  * Class to extract configuration from properties files and from command line.
@@ -98,7 +100,7 @@ public class VariantJobsArgs {
 
     private void loadVariantOptions(){
         VariantSource source = new VariantSource(
-                input,
+                Paths.get(input).getFileName().toString(),
                 fileId,
                 studyId,
                 studyName,


### PR DESCRIPTION
Previously, only the file name was stored in the "files" collection in mongo (e.g. "my_vcf.vcf.gz"). When improving the pipeline, it was changed to store the full path (e.g. "/full/path/to/my_vcf.vcf.gz").

Now, the previous behaviour of storing only the file name is restored.
